### PR TITLE
Limit no-commit-to-branch to checking only during commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     -   id: name-tests-test
         args: ['--django']
     -   id: no-commit-to-branch
+        stages: [commit]
         args: [--branch, main, --branch, master, --branch, production, --branch, staging]
     -   id: pretty-format-json
 -   repo: https://github.com/python/black


### PR DESCRIPTION
 not e.g. commit-merge.